### PR TITLE
chore: add typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "rimraf": "^2.6.1",
     "source-map-support": "^0.4.14",
     "standard-version": "^4.0.0",
-    "tslint": "^5.0.0"
+    "tslint": "^5.0.0",
+    "typescript": "^2.3.2"
   },
   "peerDependencies": {
     "typescript": ">=2.2.2"


### PR DESCRIPTION
This adds typescript to **devDependencies** to allow development without any globally installed software. Presence of typescript in devDependencies should not alter the currently picked `peerDependency` notation