### PR TITLE
feat: rewrite definition dependency imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
         "pretty": true,
         "strict": true,
         "target": "es5",
-        "inlineSourceMap": true
+        "inlineSourceMap": true,
+        "stripInternal": true
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
We need to write the import dependencies for definition files on our own
since it is out of scope for patternplate. Definition files are build
additional artifacts which are in the responsibility of the defining
transform.

Closes #10