### PR TITLE
fix: resolve correctly on win32

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ function writeDeclaration(input: PatterplateFile, output: TranspileOutput, appli
   if (output.declarationText) {
     const patterns = Object
       .keys(input.pattern.manifest.patterns || {});
-    let minDepth: number = -1;
+    let minDepth = -1;
     patterns.forEach(pattern => {
       const remote = ((input.pattern.manifest.patterns || {}) as any)[pattern];
       const remoteDepth = remote.split(sep);
@@ -88,7 +88,7 @@ function transpileFile(file: PatterplateFile, compilerOptions: ts.CompilerOption
 }
 
 function buildPattternMap(file: PatterplateFile, map: DependencyMap): void {
-  map[file.path] = file;
+  map[utils.normalizePath(file.path)] = file;
   if (file.dependencies) {
     Object
       .keys(file.dependencies)

--- a/src/transpiler.test.ts
+++ b/src/transpiler.test.ts
@@ -16,7 +16,7 @@ test('Error during declaration building should fail fast', t => {
 
       export default ColorOptions;
     `;
-    const options = ts.getDefaultCompilerOptions();
+    const options: any = ts.getDefaultCompilerOptions();
     const manifest = {};
     const root = '/tmp';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { sep } from 'path';
 import { Application, OutputArtifact } from './types';
 
 export function addOutputArtifact(application: Application, artifact: OutputArtifact): void {
@@ -9,4 +10,8 @@ export function addOutputArtifact(application: Application, artifact: OutputArti
   } else {
     console.warn(`Tried to write additional artifacts but your patternplate version is outdated. Try to update`);
   }
+}
+
+export function normalizePath(input: string): string {
+  return input.split(sep).join('/');
 }


### PR DESCRIPTION
This solves a bug where users on win32 got the exception

```
<id> coud not be found
``` 

for every pattern.

There were some typing issues I resolved, too. 

